### PR TITLE
ci(publishing): rename pre-release.yml to latest-release.yml, upload all files in dist/ folder, use a different action for only uploading the assets in tagged-release.yml

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -44,5 +44,5 @@ jobs:
           title: "🔥 Unstable Edition 🔥"
           files: |
             LICENSE
-            sync-script/build/dist/*.jar
-            admin/build/dist/*.jar
+            sync-script/build/dist/*
+            admin/build/dist/*

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -35,13 +35,8 @@ jobs:
       - name: 🛡️ Build the Minimized JAR with Proguard
         run: ./gradlew minimizedJar -i
 
-      # TODO: This GitHub action is no longer maintained https://github.com/marvinpinto/actions/commit/40312c52f0ca0d0589b25e8f5172a3613f0759c3
       - name: ⬆️ Upload the assets
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: AButler/upload-release-assets@v3.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
-          files: |
-            LICENSE
-            sync-script/build/dist/*.jar
-            admin/build/dist/*.jar
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: "LICENSE;sync-script/build/dist/*;admin/build/dist/*"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -40,3 +40,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           files: "LICENSE;sync-script/build/dist/*;admin/build/dist/*"
+          release-tag: ${{ github.ref_name }}


### PR DESCRIPTION
1. Rename `pre-release.yml` to `latest-release.yml` as we might publish tagged pre-releases.
2. Upload all assets of `dist` folder instead of JAR files only, this will also upload `build/dist/kraft-sync.map` which is used for Proguard obfuscation
3. The current action in `tagged-release.yml` automates the process of creating the release by pushing a tag, currently we want only to automate uploading the assets of the release.